### PR TITLE
Remove sbcl dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # Isle ISLISP
-Isle ISLISP is an [ISLISP](https://en.wikipedia.org/wiki/ISLISP) Compiler. It is written in Common Lisp ([Steel Bank Common Lisp](https://sbcl.org/)). Because it is implemented in Common Lisp, the source code itself demonstrates the differences between ISLISP and Common Lisp.
+Isle ISLISP is an [ISLISP](https://en.wikipedia.org/wiki/ISLISP) Compiler. It
+is written in Common Lisp. Because it is implemented in Common Lisp, the
+source code itself demonstrates the differences between ISLISP and Common
+Lisp.
 
 # Motivation for implementing in Common Lisp
-I was thinking of modifying SBCL to remove features not in ISLISP and add features as appropriate, but SBCL is constantly improving and it is difficult to keep up, so I implemented it as a Common Lisp program in SBCL. Because Isle ISLISP uses SBCL, a top-of-the-line Common Lisp implementation, execution speed is top-notch.
+I was thinking of modifying SBCL to remove features not in ISLISP and add
+features as appropriate, but SBCL is constantly improving and it is difficult
+to keep up, so I implemented it as a Common Lisp program. Because Isle ISLISP
+uses SBCL by default, a top-of-the-line Common Lisp implementation, execution
+speed is top-notch.
 
 For reference, these days Racket is also implemented in Chez Scheme.
 
@@ -11,7 +18,13 @@ For reference, these days Racket is also implemented in Chez Scheme.
 * Learn how to use macros
 * Know the difference between ISLISP and Common Lisp
 
+## Dependencies
+
+* [Quicklisp](https://www.quicklisp.org/beta/) must be installed. It will
+  handle installing other dependencies if needed.
+
 ## Run
+
 Run `isle.sh` or `isle.bat`.
 ```
 Usage: isle [OPTIONS...] [FILE]
@@ -21,6 +34,21 @@ OPTIONS:
     -v  print version.
  If no FILE is specified, the REPL is run.
 ```
+
+The shell script uses SBCL by default, but other Common Lisp implementations
+can be used by setting the `ISLE_IMPL` environment variable. Currently
+supported CLs are:
+
+* sbcl
+* ccl
+* clisp
+
+```
+ISLE_IMPL=ccl ./isle.sh
+```
+
+Other implementations can be used manually; consider enhancing the script with
+support for them if you use something else.
 
 # How to build an executable of Isle ISLISP
 Right after starting Isle ISLISP,

--- a/isle.lisp
+++ b/isle.lisp
@@ -5,7 +5,7 @@
                                        (user-homedir-pathname))))
   (when (probe-file quicklisp-init)
     (load quicklisp-init)))
-(ql:quickload '(:uiop) :silent t)
+(ql:quickload '(:uiop :with-user-abort) :silent t)
 
 (defpackage :islisp
   (:use :cl)
@@ -279,12 +279,12 @@
    (format t "> ")
    (finish-output)
    (handler-case
-       (let ((expr (read)))
-         (handler-case (format t "~s~%" (eval expr))
-           (error (e) (format t "Error: ~a~%" e))))
-       (end-of-file () (return))
-       (sb-sys:interactive-interrupt () (return)) ; Ctrl+C
-       (error (e) (format t "Error: ~a~%" e)))))
+       (with-user-abort:with-user-abort
+           (let ((expr (read)))
+             (format t "~s~%" (eval expr))))
+     (end-of-file () (uiop:quit 0 t))
+     (with-user-abort:user-abort () (uiop:quit 1 t)) ; Ctrl+C
+     (error (e) (format t "Error: ~a~%" e)))))
 
 ;; entry
 (defun main ()

--- a/isle.lisp
+++ b/isle.lisp
@@ -1,3 +1,12 @@
+;;; Load quicklisp even when not reading init files like when using sbcl
+;;; --script
+#-quicklisp
+(let ((quicklisp-init (merge-pathnames "quicklisp/setup.lisp"
+                                       (user-homedir-pathname))))
+  (when (probe-file quicklisp-init)
+    (load quicklisp-init)))
+(ql:quickload '(:uiop) :silent t)
+
 (defpackage :islisp
   (:use :cl)
   (:shadow evenp oddp file-length the class / pi load eval defclass internal-time-units-per-second))
@@ -24,7 +33,7 @@
   `(let ,(mapcar (lambda (binding) `(,(earmuff (car binding)) ,(second binding))) bindings)
      ,@(mapcar (lambda (binding) `(declare (special ,(earmuff (car binding))))) bindings)
      ,@forms))
-  
+
 (defmacro dynamic (a) `(symbol-value ',(earmuff a)))
 (defmacro set-dynamic (form var) `(setf ,form ,var))
 ;; 14. Control structure
@@ -280,10 +289,10 @@
 ;; entry
 (defun main ()
   (in-package :islisp)
-  ;;(format t "argv: ~a~%" sb-ext:*posix-argv*)
-  (let ((argv sb-ext:*posix-argv*))
-    (cond ((<= (length argv) 1) (repl))
-	  ((string= (second argv) "-h")
+  ;;(format t "argv: ~a~%" (uiop:command-line-arguments))
+  (let ((argv (uiop:command-line-arguments)))
+    (cond ((= (length argv) 0) (repl))
+	  ((string= (first argv) "-h")
 	   (write-line
 		   "Usage: isle [OPTIONS...] [FILE]
 
@@ -291,9 +300,9 @@ OPTIONS:
     -h	print this screen.
     -v	print version.
  If no FILE is specified, the REPL is run."))
-	  ((string= (second argv) "-v")
+	  ((string= (first argv) "-v")
 	   (print-version))
 	  ;; FILE
-	  (t (load (second argv))))))
+	  (t (load (first argv))))))
 
 (main)

--- a/isle.lisp
+++ b/isle.lisp
@@ -221,7 +221,9 @@
 
 ;; utility
 (defun build-exe (filename)
-  (sb-ext:save-lisp-and-die filename :toplevel #'main :executable t))
+  (setq uiop:*image-entry-point* #'main)
+  (uiop:dump-image filename :executable t)
+  (uiop:quit 0 t))
 
 ;; translator
 (defun translate-lambda-list (expr)

--- a/isle.lisp
+++ b/isle.lisp
@@ -301,9 +301,11 @@
 OPTIONS:
     -h	print this screen.
     -v	print version.
- If no FILE is specified, the REPL is run."))
+ If no FILE is specified, the REPL is run.")
+           (uiop:quit 0 t))
 	  ((string= (first argv) "-v")
-	   (print-version))
+	   (print-version)
+           (uiop:quit 0 t))
 	  ;; FILE
 	  (t (load (first argv))))))
 

--- a/isle.sh
+++ b/isle.sh
@@ -1,1 +1,15 @@
-sbcl --script "$(dirname -- "$0";)/isle.lisp" $@
+#!/bin/sh
+
+lisp=${ISLE_IMPL:-sbcl}
+isle_path="$(dirname -- "$0")/isle.lisp"
+
+if [ "$lisp" = sbcl ]; then
+    sbcl --noinform --end-runtime-options --script "$isle_path" "$@"
+elif [ "$lisp" = ccl ]; then
+    ccl --no-init --load "$isle_path" -- "$@"
+elif [ "$lisp" = clisp ]; then
+    clisp -norc -ansi "$isle_path" -- "$@"
+else
+    printf "Uknown lisp: %s\n" "$lisp" >&2
+    exit 1
+fi


### PR DESCRIPTION
I like the idea of this project, but why make it depend specifically on SBCL? This set of patches removes SBCL specific stuff in favor of using portable uiop etc. functionality (Tested with ccl and clisp, as they're the other two common lisp implementations I have installed). It does, however, add a dependency on Quicklisp, but that's already ubiquitous.